### PR TITLE
Removed edit and delete button on questions if not admin

### DIFF
--- a/app/components/question/question-preview/template.hbs
+++ b/app/components/question/question-preview/template.hbs
@@ -1,6 +1,7 @@
 {{yield}}
 <div class="ui big clearing">
   {{#if usermode}}
+{{#if user.isAdmin}}
       <button {{action "editQuestion" ques}} class="ui right floated icon button">
           <i class="edit icon"></i>
       </button>
@@ -8,7 +9,7 @@
           <i class="delete icon"></i>
       </button>
   {{/if}}
-
+{{/if}}
   <div>
   {{markdown-to-html q.question}}
   </div>


### PR DESCRIPTION
Edit and Delete button will only visible if the logged-in user is an Admin.
And the page will be visible as:-
 
![image](https://user-images.githubusercontent.com/20858804/27330522-632bfcfe-55d7-11e7-8b78-f285b3bb0614.jpg)

